### PR TITLE
Feat: ViewModel 예제 구현

### DIFF
--- a/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
@@ -17,11 +17,15 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pnu.myweather.core.util.ExternalAppUtils
 import com.pnu.myweather.feature.briefing.view.BriefingScreenActivity
+import com.pnu.myweather.feature.main.viewmodel.HomeViewModel
 import com.pnu.myweather.feature.setting.view.SettingScreenActivity
 
 class HomeScreenActivity : ComponentActivity() {
@@ -29,7 +33,9 @@ class HomeScreenActivity : ComponentActivity() {
         super.onCreate(savedInstanceState)
 
         setContent {
+            val homeViewModel: HomeViewModel = viewModel()
             HomeScreen(
+                viewModel = homeViewModel,
                 onGoToBriefing = {
                     startActivity(Intent(this, BriefingScreenActivity::class.java))
                 },
@@ -44,10 +50,13 @@ class HomeScreenActivity : ComponentActivity() {
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
 fun HomeScreen(
+    viewModel: HomeViewModel,
     onGoToBriefing: () -> Unit,
     onGoToSetting: () -> Unit
 ) {
     val context = LocalContext.current
+    val naverWeatherUrl by viewModel.naverWeatherUrl.collectAsState()
+
     Scaffold(
         topBar = {
             TopAppBar(
@@ -80,7 +89,7 @@ fun HomeScreen(
             Button(onClick = {
                 ExternalAppUtils.openBrowser(
                     context,
-                    "https://m.search.naver.com/search.naver?query=부산광역시 금정구 날씨"
+                    naverWeatherUrl
                 )
             }) {
                 Text("상세보기")

--- a/app/src/main/java/com/pnu/myweather/feature/main/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/viewmodel/HomeViewModel.kt
@@ -1,0 +1,15 @@
+package com.pnu.myweather.feature.main.viewmodel
+
+import androidx.lifecycle.ViewModel
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.StateFlow
+
+class HomeViewModel : ViewModel() {
+    private val _naverWeatherUrl =
+        MutableStateFlow("https://m.search.naver.com/search.naver?query=부산광역시 금정구 날씨")
+    val naverWeatherUrl: StateFlow<String> = _naverWeatherUrl
+
+    fun updateMessage(newUrl: String) {
+        _naverWeatherUrl.value = newUrl
+    }
+}


### PR DESCRIPTION
## 작업 설명

ViewModel 사용 방법을 연습하고 기록화 하기 위한 예제 구현

## 하위 작업

- [x]  HomeViewModel 정의
- [x]  HomeScreenActivity에 ViewModel 적용

### 변경사항

1. /main/viewmodel/HomeViewModel.kt 생성 및 뷰 모델 클래스 정의
2. HomeScreenActivity에 ViewModel 적용하여 ‘상세보기’ url을 ViewModel로 부터 획득할 수 있도록 수정