### PR TITLE
Feat: 날씨 API 연동

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
     //id("com.android.application")
     id("com.google.gms.google-services")
     alias(libs.plugins.compose.compiler)
+    id("kotlin-parcelize")
 
 }
 

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,4 +1,8 @@
-val weatherApiKey: String by project
+import java.util.Properties
+
+val localProperties = Properties().apply {
+    load(File(rootProject.projectDir, "local.properties").inputStream())
+}
 
 plugins {
     alias(libs.plugins.androidApplication)
@@ -25,7 +29,7 @@ android {
             useSupportLibrary = true
         }
 
-        buildConfigField("String", "WEATHER_API_KEY", "\"$weatherApiKey\"")
+        buildConfigField("String", "WEATHER_API_KEY", "\"${localProperties["WEATHER_API_KEY"]}\"")
     }
 
     buildTypes {
@@ -46,6 +50,7 @@ android {
     }
     buildFeatures {
         compose = true
+        buildConfig = true
     }
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+val weatherApiKey: String by project
+
 plugins {
     alias(libs.plugins.androidApplication)
     alias(libs.plugins.jetbrainsKotlinAndroid)
@@ -22,6 +24,8 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        buildConfigField("String", "WEATHER_API_KEY", "\"$weatherApiKey\"")
     }
 
     buildTypes {

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -62,6 +62,10 @@ dependencies {
     implementation("androidx.navigation:navigation-compose:2.7.7")
     implementation("com.google.mediapipe:tasks-genai:0.10.22")
 
+    implementation("com.squareup.retrofit2:retrofit:2.9.0")
+    implementation("com.squareup.retrofit2:converter-moshi:2.9.0")
+    implementation("com.squareup.okhttp3:logging-interceptor:5.0.0-alpha.2")
+
     // Default
     implementation(libs.androidx.core.ktx)
     implementation(libs.androidx.lifecycle.runtime.ktx)

--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -19,7 +19,7 @@ android {
 
     defaultConfig {
         applicationId = "com.pnu.myweather"
-        minSdk = 24
+        minSdk = 26
         targetSdk = 34
         versionCode = 1
         versionName = "1.0"

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -26,6 +26,7 @@
         <activity android:name=".feature.setting.view.SettingScreenActivity" />
         <activity android:name=".feature.briefing.view.BriefingScreenActivity" />
         <activity android:name=".feature.developer.view.DeveloperScreenActivity" />
+        <activity android:name=".feature.developer.view.PromptEditActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -25,6 +25,7 @@
         <activity android:name=".feature.main.view.HomeScreenActivity" />
         <activity android:name=".feature.setting.view.SettingScreenActivity" />
         <activity android:name=".feature.briefing.view.BriefingScreenActivity" />
+        <activity android:name=".feature.developer.view.DeveloperScreenActivity" />
     </application>
 
 </manifest>

--- a/app/src/main/assets/prompt/default_prompt.txt
+++ b/app/src/main/assets/prompt/default_prompt.txt
@@ -1,0 +1,27 @@
+You are an assistant that creates a short, helpful weather briefing in Korean based on today's and tomorrow's weather data.
+
+Instructions:
+- Write the briefing in Korean, using a friendly but not overly dramatic tone.
+- The length should be around 200 characters in Korean.
+- Include the following information clearly:
+  - current temperature (현재 기온)
+  - today's and tomorrow's high/low temperatures (최고기온, 최저기온)
+  - precipitation probability (강수확률)
+  - keywords like 오늘, 내일, 현재 must appear
+- If the temperature difference between high and low is 10°C or more, mention that the temperature range is large (일교차가 크다).
+- If precipitation probability is 60% or more, remind users to bring an umbrella.
+- If precipitation probability is low and the sky is clear, recommend outdoor activities.
+- Do not mention an umbrella if the chance of rain is 10% or less.
+- Do not mention temperature variation warnings if the difference is less than 10°C.
+- 답변의 첫 문장은 '안녕하세요 오늘의 날씨 브리핑을 알려드립니다'로 시작해야 한다.
+- 답변의 마지막 문장은 '지금까지 날씨 브리핑이었습니다.'로 끝나야 한다.
+- 답변의 문장 사이에는 줄 바꿈이 있어야 한다.
+
+Example output (in Korean):
+안녕하세요 오늘의 날씨 브리핑을 알려드립니다.
+현재 기온은 21도로 맑은 날씨입니다.
+오늘의 최고 기온은 28도, 최저 기온은 16도로 일교차가 크니 겉옷을 챙기시는 편이 좋겠습니다.
+강수확률은 0%로 비가 올 확률은 낮으며 야외 활동하기에 좋은 날씨입니다.
+지금까지 날씨 브리핑이었습니다.
+
+Now, generate a Korean weather briefing based on the following data:

--- a/app/src/main/java/com/pnu/myweather/core/gemma/GemmaModelLoader.kt
+++ b/app/src/main/java/com/pnu/myweather/core/gemma/GemmaModelLoader.kt
@@ -16,7 +16,7 @@ object GemmaModelLoader {
 
         val interfaceOptions = LlmInference.LlmInferenceOptions.builder()
             .setModelPath(destinationFile.absolutePath)
-            .setMaxTokens(1000)
+            .setMaxTokens(2000)
             .setPreferredBackend(LlmInference.Backend.CPU)
             .build()
 

--- a/app/src/main/java/com/pnu/myweather/core/gemma/PromptProvider.kt
+++ b/app/src/main/java/com/pnu/myweather/core/gemma/PromptProvider.kt
@@ -1,43 +1,13 @@
 package com.pnu.myweather.core.gemma
 
+import android.content.Context
 import com.pnu.myweather.core.weather.WeatherSummary
+import java.io.File
 
 object PromptProvider {
-    fun getFullPrompt(current: WeatherSummary?): String {
-        return getDefaultPrompt() + getWeatherBriefingPrompt(current)
+    fun getFullPrompt(context: Context, current: WeatherSummary?): String {
+        return loadPrompt(context) + getWeatherBriefingPrompt(current)
     }
-
-    fun getDefaultPrompt(): String = """
-        You are an assistant that creates a short, helpful weather briefing in Korean based on today's and tomorrow's weather data.
-
-        Instructions:
-        - Write the briefing in Korean, using a friendly but not overly dramatic tone.
-        - The length should be around 200 characters in Korean.
-        - Include the following information clearly:
-          - current temperature (현재 기온)
-          - today's and tomorrow's high/low temperatures (최고기온, 최저기온)
-          - precipitation probability (강수확률)
-          - keywords like 오늘, 내일, 현재 must appear
-        - If the temperature difference between high and low is 10°C or more, mention that the temperature range is large (일교차가 크다).
-        - If precipitation probability is 60% or more, remind users to bring an umbrella.
-        - If precipitation probability is low and the sky is clear, recommend outdoor activities.
-        - Do not mention an umbrella if the chance of rain is 10% or less.
-        - Do not mention temperature variation warnings if the difference is less than 10°C.
-        - 답변의 첫 문장은 '안녕하세요 오늘의 날씨 브리핑을 알려드립니다'로 시작해야 한다.
-        - 답변의 마지막 문장은 '지금까지 날씨 브리핑이었습니다.'로 끝나야 한다.
-        - 답변의 문장 사이에는 줄 바꿈이 있어야 한다.
-        
-        Example output (in Korean):
-        안녕하세요 오늘의 날씨 브리핑을 알려드립니다.
-        현재 기온은 21도로 맑은 날씨입니다.
-        오늘의 최고 기온은 28도, 최저 기온은 16도로 일교차가 크니 겉옷을 챙기시는 편이 좋겠습니다. 
-        강수확률은 0%로 비가 올 확률은 낮으며 야외 활동하기에 좋은 날씨입니다.
-        지금까지 날씨 브리핑이었습니다.
-
-        Now, generate a Korean weather briefing based on the following data:
-        
-        
-    """.trimIndent()
 
     fun getWeatherBriefingPrompt(current: WeatherSummary?): String {
         fun WeatherSummary?.describe(prefix: String): String {
@@ -56,5 +26,31 @@ object PromptProvider {
         return listOf(
             current.describe("현재"),
         ).joinToString("\n\n")
+    }
+
+    private const val FILE_NAME = "editable_prompt.txt"
+
+    fun loadPrompt(context: Context): String {
+        val file = File(context.filesDir, FILE_NAME)
+
+        if (!file.exists()) {
+            // 기본 프롬프트로 초기화
+            val defaultPrompt = context.assets.open("prompt/default_prompt.txt")
+                .bufferedReader().use { it.readText() }
+            file.writeText(defaultPrompt)
+            return defaultPrompt
+        }
+
+        return file.readText()
+    }
+
+    fun savePrompt(context: Context, prompt: String) {
+        File(context.filesDir, FILE_NAME).writeText(prompt)
+    }
+
+    fun resetPrompt(context: Context) {
+        val defaultPrompt = context.assets.open("prompt/default_prompt.txt")
+            .bufferedReader().use { it.readText() }
+        File(context.filesDir, FILE_NAME).writeText(defaultPrompt)
     }
 }

--- a/app/src/main/java/com/pnu/myweather/core/gemma/PromptProvider.kt
+++ b/app/src/main/java/com/pnu/myweather/core/gemma/PromptProvider.kt
@@ -8,9 +8,34 @@ object PromptProvider {
     }
 
     fun getDefaultPrompt(): String = """
-        아래 날씨 데이터를 기반으로, 다음 조건에 따라 400자 내외의 짧고 친절한 날씨 브리핑을 만들어줘.
-        최저, 최고 기온이 10도 이상 차이나면 일교차가 크다고 알려줘
-        만약 강수확률이 60% 이상이면 우산을 챙기라는 말을 덧붙여 줘
+        You are an assistant that creates a short, helpful weather briefing in Korean based on today's and tomorrow's weather data.
+
+        Instructions:
+        - Write the briefing in Korean, using a friendly but not overly dramatic tone.
+        - The length should be around 200 characters in Korean.
+        - Include the following information clearly:
+          - current temperature (현재 기온)
+          - today's and tomorrow's high/low temperatures (최고기온, 최저기온)
+          - precipitation probability (강수확률)
+          - keywords like 오늘, 내일, 현재 must appear
+        - If the temperature difference between high and low is 10°C or more, mention that the temperature range is large (일교차가 크다).
+        - If precipitation probability is 60% or more, remind users to bring an umbrella.
+        - If precipitation probability is low and the sky is clear, recommend outdoor activities.
+        - Do not mention an umbrella if the chance of rain is 10% or less.
+        - Do not mention temperature variation warnings if the difference is less than 10°C.
+        - 답변의 첫 문장은 '안녕하세요 오늘의 날씨 브리핑을 알려드립니다'로 시작해야 한다.
+        - 답변의 마지막 문장은 '지금까지 날씨 브리핑이었습니다.'로 끝나야 한다.
+        - 답변의 문장 사이에는 줄 바꿈이 있어야 한다.
+        
+        Example output (in Korean):
+        안녕하세요 오늘의 날씨 브리핑을 알려드립니다.
+        현재 기온은 21도로 맑은 날씨입니다.
+        오늘의 최고 기온은 28도, 최저 기온은 16도로 일교차가 크니 겉옷을 챙기시는 편이 좋겠습니다. 
+        강수확률은 0%로 비가 올 확률은 낮으며 야외 활동하기에 좋은 날씨입니다.
+        지금까지 날씨 브리핑이었습니다.
+
+        Now, generate a Korean weather briefing based on the following data:
+        
         
     """.trimIndent()
 

--- a/app/src/main/java/com/pnu/myweather/core/gemma/PromptProvider.kt
+++ b/app/src/main/java/com/pnu/myweather/core/gemma/PromptProvider.kt
@@ -1,9 +1,35 @@
 package com.pnu.myweather.core.gemma
 
+import com.pnu.myweather.core.weather.WeatherSummary
+
 object PromptProvider {
+    fun getFullPrompt(current: WeatherSummary?): String {
+        return getDefaultPrompt() + getWeatherBriefingPrompt(current)
+    }
+
     fun getDefaultPrompt(): String = """
-        아래 날씨 데이터를 기반으로, 다음 조건에 따라 500자 내외의 짧고 친절한 날씨 브리핑을 만들어줘.
-        1. 오늘 날씨에 대한 요약을 한 문장으로 제시해줘. (예: 비교적 서늘한 날씨입니다, 구름이 많은 날씨입니다 등)
-        2. 날씨에 따라 시민들에게 도움이 될 만한 행동 조언을 한 문장으로 덧붙여줘. (예: 일교차가 크니 외투를 챙기세요, 자외선이 강하니 모자를 착용하세요 등)
+        아래 날씨 데이터를 기반으로, 다음 조건에 따라 400자 내외의 짧고 친절한 날씨 브리핑을 만들어줘.
+        최저, 최고 기온이 10도 이상 차이나면 일교차가 크다고 알려줘
+        만약 강수확률이 60% 이상이면 우산을 챙기라는 말을 덧붙여 줘
+        
     """.trimIndent()
+
+    fun getWeatherBriefingPrompt(current: WeatherSummary?): String {
+        fun WeatherSummary?.describe(prefix: String): String {
+            if (this == null) return "$prefix 날씨 정보를 불러오지 못했습니다."
+            return buildString {
+                appendLine("$prefix 날씨입니다.")
+                temperature?.let { appendLine("현재 기온은 ${it}입니다.") }
+                skyState?.let { appendLine("하늘 상태는 ${it}입니다.") }
+                minTemp?.let { appendLine("최저 기온은 ${it}입니다.") }
+                maxTemp?.let { appendLine("최고 기온은 ${it}입니다.") }
+                humidity?.let { appendLine("습도는 ${it}입니다.") }
+                precipitation?.let { appendLine("강수 확률은 ${it}입니다.") }
+            }
+        }
+
+        return listOf(
+            current.describe("현재"),
+        ).joinToString("\n\n")
+    }
 }

--- a/app/src/main/java/com/pnu/myweather/core/util/WeatherApiUtils.kt
+++ b/app/src/main/java/com/pnu/myweather/core/util/WeatherApiUtils.kt
@@ -1,0 +1,29 @@
+package com.pnu.myweather.core.util
+
+import android.annotation.SuppressLint
+import android.os.Build
+import androidx.annotation.RequiresApi
+import java.time.LocalDateTime
+import java.time.format.DateTimeFormatter
+
+@SuppressLint("DefaultLocale")
+@RequiresApi(Build.VERSION_CODES.O)
+fun getLatestBaseDateTime(): Pair<String, String> {
+    val now = LocalDateTime.now()
+    val timeTable = listOf(2, 5, 8, 11, 14, 17, 20, 23)
+
+    // 가장 가까운 이전 발표 시각 찾기
+    val baseHour = timeTable.lastOrNull { it <= now.hour }
+        ?: 23 // 0~1시는 전날 23시 예보 사용
+
+    // 0시~1시라면 전날 날짜 사용
+    val baseDate = if (now.hour < 2) {
+        now.minusDays(1).format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+    } else {
+        now.format(DateTimeFormatter.ofPattern("yyyyMMdd"))
+    }
+
+    val baseTime = String.format("%02d00", baseHour) // ex) "1400"
+
+    return baseDate to baseTime
+}

--- a/app/src/main/java/com/pnu/myweather/core/util/WeatherApiUtils.kt
+++ b/app/src/main/java/com/pnu/myweather/core/util/WeatherApiUtils.kt
@@ -1,13 +1,10 @@
 package com.pnu.myweather.core.util
 
 import android.annotation.SuppressLint
-import android.os.Build
-import androidx.annotation.RequiresApi
 import java.time.LocalDateTime
 import java.time.format.DateTimeFormatter
 
 @SuppressLint("DefaultLocale")
-@RequiresApi(Build.VERSION_CODES.O)
 fun getLatestBaseDateTime(): Pair<String, String> {
     val now = LocalDateTime.now()
     val timeTable = listOf(2, 5, 8, 11, 14, 17, 20, 23)
@@ -26,4 +23,23 @@ fun getLatestBaseDateTime(): Pair<String, String> {
     val baseTime = String.format("%02d00", baseHour) // ex) "1400"
 
     return baseDate to baseTime
+}
+
+fun getWeatherDescription(sky: String, pty: String): String {
+    return when (pty) {
+        "0" -> { // 강수 없음 → 하늘 상태 기준
+            when (sky) {
+                "1" -> "맑음"
+                "3" -> "구름 많음"
+                "4" -> "흐림"
+                else -> "알 수 없음"
+            }
+        }
+
+        "1" -> "비"
+        "2" -> "비 또는 눈"
+        "3" -> "눈"
+        "4" -> "소나기"
+        else -> "강수 정보 없음"
+    }
 }

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiClient.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiClient.kt
@@ -4,7 +4,7 @@ import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
 
 object WeatherApiClient {
-    private const val BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/"
+    private const val BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/"
 
     private val retrofit: Retrofit by lazy {
         Retrofit.Builder()

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiClient.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiClient.kt
@@ -1,14 +1,23 @@
 package com.pnu.myweather.core.weather
 
+import okhttp3.OkHttpClient
 import retrofit2.Retrofit
 import retrofit2.converter.moshi.MoshiConverterFactory
+import java.util.concurrent.TimeUnit
 
 object WeatherApiClient {
     private const val BASE_URL = "https://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/"
 
+    private val okHttpClient = OkHttpClient.Builder()
+        .connectTimeout(20, TimeUnit.SECONDS)
+        .readTimeout(30, TimeUnit.SECONDS)
+        .writeTimeout(30, TimeUnit.SECONDS)
+        .build()
+
     private val retrofit: Retrofit by lazy {
         Retrofit.Builder()
             .baseUrl(BASE_URL)
+            .client(okHttpClient)  // 👈 timeout 설정 반영
             .addConverterFactory(MoshiConverterFactory.create())
             .build()
     }

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiClient.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiClient.kt
@@ -1,0 +1,19 @@
+package com.pnu.myweather.core.weather
+
+import retrofit2.Retrofit
+import retrofit2.converter.moshi.MoshiConverterFactory
+
+object WeatherApiClient {
+    private const val BASE_URL = "http://apis.data.go.kr/1360000/VilageFcstInfoService_2.0/"
+
+    private val retrofit: Retrofit by lazy {
+        Retrofit.Builder()
+            .baseUrl(BASE_URL)
+            .addConverterFactory(MoshiConverterFactory.create())
+            .build()
+    }
+
+    val service: WeatherApiService by lazy {
+        retrofit.create(WeatherApiService::class.java)
+    }
+}

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiService.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherApiService.kt
@@ -1,0 +1,19 @@
+package com.pnu.myweather.core.weather
+
+import retrofit2.http.GET
+import retrofit2.http.Query
+
+interface WeatherApiService {
+
+    @GET("getVilageFcst")
+    suspend fun getForecast(
+        @Query("serviceKey", encoded = true) serviceKey: String,
+        @Query("base_date") baseDate: String,
+        @Query("base_time") baseTime: String,
+        @Query("nx") nx: Int,
+        @Query("ny") ny: Int,
+        @Query("dataType") dataType: String = "JSON",
+        @Query("numOfRows") numOfRows: Int = 100,
+        @Query("pageNo") pageNo: Int = 1
+    ): WeatherResponse
+}

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherResponse.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherResponse.kt
@@ -1,0 +1,28 @@
+package com.pnu.myweather.core.weather
+
+data class WeatherResponse(
+    val response: ResponseData
+)
+
+data class ResponseData(
+    val body: BodyData
+)
+
+data class BodyData(
+    val items: ItemsData
+)
+
+data class ItemsData(
+    val item: List<ForecastItem>
+)
+
+data class ForecastItem(
+    val baseDate: String,
+    val baseTime: String,
+    val category: String,
+    val fcstDate: String,
+    val fcstTime: String,
+    val fcstValue: String,
+    val nx: Int,
+    val ny: Int
+)

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherSummary.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherSummary.kt
@@ -1,5 +1,11 @@
 package com.pnu.myweather.core.weather
 
+import android.annotation.SuppressLint
+import android.os.Parcelable
+import kotlinx.parcelize.Parcelize
+
+@SuppressLint("ParcelCreator")
+@Parcelize
 data class WeatherSummary(
     val temperature: String?,
     val skyState: String?,
@@ -7,4 +13,4 @@ data class WeatherSummary(
     val maxTemp: String?,
     val humidity: String?,
     val precipitation: String?
-)
+) : Parcelable

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherSummary.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherSummary.kt
@@ -1,0 +1,10 @@
+package com.pnu.myweather.core.weather
+
+data class WeatherSummary(
+    val temperature: String?,
+    val skyState: String?,
+    val minTemp: String?,
+    val maxTemp: String?,
+    val humidity: String?,
+    val precipitation: String?
+)

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherUiState.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherUiState.kt
@@ -2,6 +2,9 @@ package com.pnu.myweather.core.weather
 
 sealed class WeatherUiState {
     object Loading : WeatherUiState()
-    data class Success(val items: List<ForecastItem>) : WeatherUiState()
+    data class Success(
+        val groupedForecasts: Map<Pair<String, String>, List<ForecastItem>>
+    ) : WeatherUiState()
+
     data class Error(val message: String) : WeatherUiState()
 }

--- a/app/src/main/java/com/pnu/myweather/core/weather/WeatherUiState.kt
+++ b/app/src/main/java/com/pnu/myweather/core/weather/WeatherUiState.kt
@@ -1,0 +1,7 @@
+package com.pnu.myweather.core.weather
+
+sealed class WeatherUiState {
+    object Loading : WeatherUiState()
+    data class Success(val items: List<ForecastItem>) : WeatherUiState()
+    data class Error(val message: String) : WeatherUiState()
+}

--- a/app/src/main/java/com/pnu/myweather/feature/briefing/view/BriefingScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/briefing/view/BriefingScreenActivity.kt
@@ -154,7 +154,7 @@ fun BriefingScreen(
                 is GemmaState.Ready -> {
                     val scrollableState = rememberScrollState()
 
-                    val prompt = PromptProvider.getFullPrompt(weatherSummary)
+                    val prompt = PromptProvider.getFullPrompt(context, weatherSummary)
                     val localSessionManager = state.sessionManager
                     val response by localSessionManager.response.collectAsState()
                     val isResponding by localSessionManager.responding.collectAsState()

--- a/app/src/main/java/com/pnu/myweather/feature/developer/view/DeveloperScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/developer/view/DeveloperScreenActivity.kt
@@ -1,0 +1,64 @@
+package com.pnu.myweather.feature.developer.view
+
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.unit.dp
+
+class DeveloperScreenActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            DeveloperScreen()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DeveloperScreen() {
+    val activity = LocalActivity.current
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("🛠️ Developer Options") },
+                navigationIcon = {
+                    IconButton(onClick = { activity?.finish() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.Start
+        ) {
+            Spacer(modifier = Modifier.height(16.dp))
+            // Add more options or debug toggles here
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/myweather/feature/developer/view/DeveloperScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/developer/view/DeveloperScreenActivity.kt
@@ -1,18 +1,17 @@
 package com.pnu.myweather.feature.developer.view
 
-
+import android.content.Intent
 import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.LocalActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
@@ -20,9 +19,10 @@ import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
 import androidx.compose.material3.TopAppBar
 import androidx.compose.runtime.Composable
-import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
+
 
 class DeveloperScreenActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {
@@ -37,16 +37,15 @@ class DeveloperScreenActivity : ComponentActivity() {
 @Composable
 fun DeveloperScreen() {
     val activity = LocalActivity.current
+    val context = LocalContext.current
+
     Scaffold(
         topBar = {
-            TopAppBar(
-                title = { Text("🛠️ Developer Options") },
-                navigationIcon = {
-                    IconButton(onClick = { activity?.finish() }) {
-                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
-                    }
+            TopAppBar(title = { Text("🛠️ Developer Options") }, navigationIcon = {
+                IconButton(onClick = { activity?.finish() }) {
+                    Icon(Icons.Default.ArrowBack, contentDescription = "Back")
                 }
-            )
+            })
         }
     ) { padding ->
         Column(
@@ -54,11 +53,17 @@ fun DeveloperScreen() {
                 .padding(padding)
                 .fillMaxSize()
                 .padding(16.dp),
-            verticalArrangement = Arrangement.Top,
-            horizontalAlignment = Alignment.Start
+            verticalArrangement = Arrangement.Top
         ) {
-            Spacer(modifier = Modifier.height(16.dp))
-            // Add more options or debug toggles here
+            Button(
+                onClick = {
+                    context.startActivity(Intent(context, PromptEditActivity::class.java))
+                }
+            ) {
+                Text("기본 프롬프트 수정")
+            }
+
+            // 앞으로 여기 다른 개발자용 기능 버튼들도 추가하면 돼!
         }
     }
 }

--- a/app/src/main/java/com/pnu/myweather/feature/developer/view/PromptEditActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/developer/view/PromptEditActivity.kt
@@ -1,0 +1,111 @@
+package com.pnu.myweather.feature.developer.view
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.LocalActivity
+import androidx.activity.compose.setContent
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.Scaffold
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
+import androidx.compose.material3.TopAppBar
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.unit.dp
+import com.pnu.myweather.core.gemma.PromptProvider
+
+
+class PromptEditActivity : ComponentActivity() {
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            PromptEditScreen()
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun PromptEditScreen() {
+    val activity = LocalActivity.current
+    val context = LocalContext.current
+    var promptText by remember { mutableStateOf(PromptProvider.loadPrompt(context)) }
+
+    Scaffold(
+        topBar = {
+            TopAppBar(
+                title = { Text("프롬프트 수정") },
+                navigationIcon = {
+                    IconButton(onClick = { activity?.finish() }) {
+                        Icon(Icons.Default.ArrowBack, contentDescription = "Back")
+                    }
+                }
+            )
+        }
+    ) { padding ->
+        Column(
+            modifier = Modifier
+                .padding(padding)
+                .fillMaxSize()
+                .padding(16.dp),
+            verticalArrangement = Arrangement.Top,
+            horizontalAlignment = Alignment.Start
+        ) {
+            Text(
+                "🧾 프롬프트 수정",
+                style = androidx.compose.material3.MaterialTheme.typography.titleMedium
+            )
+            Spacer(modifier = Modifier.height(8.dp))
+
+            TextField(
+                value = promptText,
+                onValueChange = { promptText = it },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .weight(1f),
+                singleLine = false,
+            )
+
+            Spacer(modifier = Modifier.height(16.dp))
+
+            Button(
+                onClick = {
+                    PromptProvider.savePrompt(context, promptText)
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("프롬프트 저장")
+            }
+
+            Spacer(modifier = Modifier.height(8.dp))
+
+            Button(
+                onClick = {
+                    PromptProvider.resetPrompt(context)
+                    promptText = PromptProvider.loadPrompt(context)
+                },
+                modifier = Modifier.fillMaxWidth()
+            ) {
+                Text("기본값으로 초기화")
+            }
+        }
+    }
+}

--- a/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
@@ -42,7 +42,12 @@ class HomeScreenActivity : ComponentActivity() {
             HomeScreen(
                 viewModel = homeViewModel,
                 onGoToBriefing = {
-                    startActivity(Intent(this, BriefingScreenActivity::class.java))
+                    val weatherSummary = homeViewModel.weatherSummary.value
+                    val intent = Intent(this, BriefingScreenActivity::class.java).apply {
+                        putExtra("weatherSummary", weatherSummary)
+                        // TODO: tomorrowSummary도 필요하면 같이 넣기
+                    }
+                    startActivity(intent)
                 },
                 onGoToSetting = {
                     startActivity(Intent(this, SettingScreenActivity::class.java))

--- a/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import androidx.lifecycle.viewmodel.compose.viewModel
 import com.pnu.myweather.BuildConfig
 import com.pnu.myweather.core.util.ExternalAppUtils
+import com.pnu.myweather.core.util.getLatestBaseDateTime
 import com.pnu.myweather.core.weather.WeatherUiState
 import com.pnu.myweather.feature.briefing.view.BriefingScreenActivity
 import com.pnu.myweather.feature.main.viewmodel.HomeViewModel
@@ -61,11 +62,12 @@ fun HomeScreen(
     val context = LocalContext.current
     val naverWeatherUrl by viewModel.naverWeatherUrl.collectAsState()
     val weatherState by viewModel.weatherState.collectAsState()
-
+    val (baseDate, baseTime) = getLatestBaseDateTime()
     LaunchedEffect(Unit) {
+
         viewModel.fetchWeather(
-            baseDate = "20250526", // TODO: 수정 필요
-            baseTime = "0500",     // TODO: 수정 필요
+            baseDate = baseDate,
+            baseTime = baseTime,
             nx = 98, ny = 76       // ex) 장전동 (부산 금정구)
         )
     }
@@ -91,6 +93,8 @@ fun HomeScreen(
                 .fillMaxSize()
                 .padding(16.dp)
         ) {
+            Text(baseDate)
+            Text(baseTime)
             when (weatherState) {
                 is WeatherUiState.Loading -> {
                     Text("날씨 불러오는 중...")
@@ -105,7 +109,7 @@ fun HomeScreen(
                     val items = (weatherState as WeatherUiState.Success).items
 
                     Text("날씨 정보 (${items.size}개):")
-                    items.take(5).forEach { item ->  // 예시로 5개만 출력
+                    items.forEach { item ->  // 예시로 5개만 출력
                         Text(
                             text = "${item.fcstDate} ${item.fcstTime} | ${item.category} = ${item.fcstValue}"
                         )

--- a/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
@@ -142,7 +142,7 @@ fun HomeScreen(
             }) {
                 Text("상세보기")
             }
-            Button(onClick = onGoToBriefing) {
+            Button(onClick = onGoToBriefing, enabled = weatherState is WeatherUiState.Success) {
                 Text("브리핑")
             }
         }

--- a/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
@@ -62,6 +62,7 @@ fun HomeScreen(
     val context = LocalContext.current
     val naverWeatherUrl by viewModel.naverWeatherUrl.collectAsState()
     val weatherState by viewModel.weatherState.collectAsState()
+    val weatherSummary by viewModel.weatherSummary.collectAsState()
     val (baseDate, baseTime) = getLatestBaseDateTime()
     LaunchedEffect(Unit) {
 
@@ -95,6 +96,7 @@ fun HomeScreen(
         ) {
             Text(baseDate)
             Text(baseTime)
+
             when (weatherState) {
                 is WeatherUiState.Loading -> {
                     Text("날씨 불러오는 중...")
@@ -106,13 +108,14 @@ fun HomeScreen(
                 }
 
                 is WeatherUiState.Success -> {
-                    val items = (weatherState as WeatherUiState.Success).items
-
-                    Text("날씨 정보 (${items.size}개):")
-                    items.forEach { item ->  // 예시로 5개만 출력
-                        Text(
-                            text = "${item.fcstDate} ${item.fcstTime} | ${item.category} = ${item.fcstValue}"
-                        )
+                    weatherSummary?.let {
+                        Text("현재 기온: ${it.temperature}")
+                        Text("하늘 상태: ${it.skyState}")
+                        Text("최고 기온: ${it.maxTemp}")
+                        Text("최저 기온: ${it.minTemp}")
+                        Text("습도: ${it.humidity}")
+                        Text("강수 확률: ${it.precipitation}")
+                        Spacer(modifier = Modifier.padding(top = 16.dp))
                     }
                 }
             }

--- a/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/HomeScreenActivity.kt
@@ -30,6 +30,7 @@ import com.pnu.myweather.core.util.ExternalAppUtils
 import com.pnu.myweather.core.util.getLatestBaseDateTime
 import com.pnu.myweather.core.weather.WeatherUiState
 import com.pnu.myweather.feature.briefing.view.BriefingScreenActivity
+import com.pnu.myweather.feature.developer.view.DeveloperScreenActivity
 import com.pnu.myweather.feature.main.viewmodel.HomeViewModel
 import com.pnu.myweather.feature.setting.view.SettingScreenActivity
 
@@ -81,7 +82,11 @@ fun HomeScreen(
     Scaffold(
         topBar = {
             TopAppBar(
-                title = { Text("MyWeather") },
+                title = {
+                    SecretAppBarTitle("Weather") {
+                        context.startActivity(Intent(context, DeveloperScreenActivity::class.java))
+                    }
+                },
                 actions = {
                     IconButton(onClick = onGoToSetting) {
                         Icon(

--- a/app/src/main/java/com/pnu/myweather/feature/main/view/SecretAppBarTitle.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/view/SecretAppBarTitle.kt
@@ -1,0 +1,33 @@
+package com.pnu.myweather.feature.main.view
+
+import androidx.compose.foundation.gestures.detectTapGestures
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.input.pointer.pointerInput
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun SecretAppBarTitle(title: String, onUnlock: () -> Unit) {
+    var clickCount by remember { mutableStateOf(0) }
+
+    Text(
+        text = title,
+        modifier = Modifier
+            .padding(8.dp)
+            .pointerInput(Unit) {
+                detectTapGestures(onTap = {
+                    clickCount++
+                    if (clickCount >= 5) {
+                        onUnlock()
+                        clickCount = 0
+                    }
+                })
+            }
+    )
+}

--- a/app/src/main/java/com/pnu/myweather/feature/main/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/viewmodel/HomeViewModel.kt
@@ -3,8 +3,10 @@ package com.pnu.myweather.feature.main.viewmodel
 import androidx.lifecycle.ViewModel
 import androidx.lifecycle.viewModelScope
 import com.pnu.myweather.BuildConfig
+import com.pnu.myweather.core.util.getWeatherDescription
 import com.pnu.myweather.core.weather.ForecastItem
 import com.pnu.myweather.core.weather.WeatherApiClient
+import com.pnu.myweather.core.weather.WeatherSummary
 import com.pnu.myweather.core.weather.WeatherUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
@@ -23,6 +25,9 @@ class HomeViewModel : ViewModel() {
     private val _weatherState = MutableStateFlow<WeatherUiState>(WeatherUiState.Loading)
     val weatherState: StateFlow<WeatherUiState> = _weatherState
 
+    private val _weatherSummary = MutableStateFlow<WeatherSummary?>(null)
+    val weatherSummary: StateFlow<WeatherSummary?> = _weatherSummary
+
     fun fetchWeather(
         baseDate: String,
         baseTime: String,
@@ -40,11 +45,57 @@ class HomeViewModel : ViewModel() {
                     ny = ny,
                     dataType = "JSON"
                 )
-                val items: List<ForecastItem> = response.response.body.items.item
-                _weatherState.value = WeatherUiState.Success(items)
+                val items = response.response.body.items.item
+                processWeatherData(response.response.body.items.item)
             } catch (e: Exception) {
                 _weatherState.value = WeatherUiState.Error(e.message ?: "알 수 없는 에러")
             }
         }
+    }
+
+    private fun processWeatherData(items: List<ForecastItem>) {
+        val requiredCategories = setOf("TMP", "SKY", "PTY", "REH", "POP")
+        val grouped = items.groupBy { it.fcstDate to it.fcstTime }
+
+        val filteredGrouped = grouped.filterValues { forecasts ->
+            val presentCategories = forecasts.map { it.category }.toSet()
+            requiredCategories.all { it in presentCategories }
+        }
+
+        val earliestEntry = filteredGrouped.entries.minByOrNull { (dateTime, _) ->
+            val (date, time) = dateTime
+            "$date$time"
+        }
+        val earliest = earliestEntry?.value ?: emptyList()
+
+        fun findValue(category: String, from: List<ForecastItem>): String? =
+            from.find { it.category == category }?.fcstValue
+
+        val currentTemp = findValue("TMP", earliest)?.let { "$it°C" }
+        val currentSky = findValue("SKY", earliest)
+        val currentPty = findValue("PTY", earliest)
+        val currentWeather = if (currentSky != null && currentPty != null) {
+            getWeatherDescription(currentSky, currentPty)
+        } else null
+        val humidity = findValue("REH", earliest)?.let { "$it%" }
+        val pop = findValue("POP", earliest)?.let { "$it%" }
+
+        val temperatureValues = items
+            .filter { it.category == "TMP" }
+            .mapNotNull { it.fcstValue.toFloatOrNull() }
+
+        val minTemp = temperatureValues.minOrNull()?.let { "${it}°C" } ?: "정보 없음"
+        val maxTemp = temperatureValues.maxOrNull()?.let { "${it}°C" } ?: "정보 없음"
+
+        _weatherSummary.value = WeatherSummary(
+            temperature = currentTemp,
+            skyState = currentWeather,
+            minTemp = minTemp,
+            maxTemp = maxTemp,
+            humidity = humidity,
+            precipitation = pop
+        )
+
+        _weatherState.value = WeatherUiState.Success(filteredGrouped)
     }
 }

--- a/app/src/main/java/com/pnu/myweather/feature/main/viewmodel/HomeViewModel.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/main/viewmodel/HomeViewModel.kt
@@ -1,15 +1,50 @@
 package com.pnu.myweather.feature.main.viewmodel
 
 import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.pnu.myweather.BuildConfig
+import com.pnu.myweather.core.weather.ForecastItem
+import com.pnu.myweather.core.weather.WeatherApiClient
+import com.pnu.myweather.core.weather.WeatherUiState
 import kotlinx.coroutines.flow.MutableStateFlow
 import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.launch
 
 class HomeViewModel : ViewModel() {
+
     private val _naverWeatherUrl =
         MutableStateFlow("https://m.search.naver.com/search.naver?query=부산광역시 금정구 날씨")
     val naverWeatherUrl: StateFlow<String> = _naverWeatherUrl
 
     fun updateMessage(newUrl: String) {
         _naverWeatherUrl.value = newUrl
+    }
+
+    private val _weatherState = MutableStateFlow<WeatherUiState>(WeatherUiState.Loading)
+    val weatherState: StateFlow<WeatherUiState> = _weatherState
+
+    fun fetchWeather(
+        baseDate: String,
+        baseTime: String,
+        nx: Int,
+        ny: Int
+    ) {
+        viewModelScope.launch {
+            _weatherState.value = WeatherUiState.Loading
+            try {
+                val response = WeatherApiClient.service.getForecast(
+                    serviceKey = BuildConfig.WEATHER_API_KEY,
+                    baseDate = baseDate,
+                    baseTime = baseTime,
+                    nx = nx,
+                    ny = ny,
+                    dataType = "JSON"
+                )
+                val items: List<ForecastItem> = response.response.body.items.item
+                _weatherState.value = WeatherUiState.Success(items)
+            } catch (e: Exception) {
+                _weatherState.value = WeatherUiState.Error(e.message ?: "알 수 없는 에러")
+            }
+        }
     }
 }

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,3 +21,4 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+weatherApiKey=${WEATHER_API_KEY}

--- a/gradle.properties
+++ b/gradle.properties
@@ -21,4 +21,5 @@ kotlin.code.style=official
 # resources declared in the library itself and none from the library's dependencies,
 # thereby reducing the size of the R class for that library
 android.nonTransitiveRClass=true
+android.defaults.buildfeatures.buildconfig=true
 weatherApiKey=${WEATHER_API_KEY}


### PR DESCRIPTION
### 개요
날씨 API 연동

### 목적
날씨API 를 연동하여 홈 화면 초안 구현 및 추가 작업 진행

### 변경 사항
- 날씨 API 호출을 위한 로직 작성
 - API 클라이언트, 유틸함수 등
- 현재 날씨 정보를 Intent를 통해 브리핑 화면으로 전달
- 브리핑 화면에서 전달받은 날씨 데이터로 브리핑 생성
- 개발자 화면 구현
 - 기본 프롬프트 수정 가능
 - 추후 현재 설정 지역 초기화 가능하도록 추가 예정

### 참고 사항
- local.properties에 날씨 API Key 등록 필요