### PR TITLE
feat: 설정 화면에서 지역 저장 로직 구현

### DIFF
--- a/app/src/main/java/com/pnu/myweather/feature/setting/view/LocationPreference.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/setting/view/LocationPreference.kt
@@ -1,0 +1,41 @@
+package com.pnu.myweather.feature.setting.view
+
+import android.content.Context
+import android.content.SharedPreferences
+
+object LocationPreference {
+
+    private const val PREF_NAME = "location_pref"
+    private const val KEY_SIDO = "sido"
+    private const val KEY_GU = "gu"
+    private const val KEY_DONG = "dong"
+    private const val KEY_NX = "nx"
+    private const val KEY_NY = "ny"
+
+    private fun prefs(context: Context): SharedPreferences {
+        return context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
+    }
+
+    // 저장
+    fun save(context: Context, sido: String, gu: String, dong: String, nx: Int, ny: Int) {
+        prefs(context).edit().apply {
+            putString(KEY_SIDO, sido)
+            putString(KEY_GU, gu)
+            putString(KEY_DONG, dong)
+            putInt(KEY_NX, nx)
+            putInt(KEY_NY, ny)
+            apply()
+        }
+    }
+
+    // 불러오기
+    fun getSido(context: Context): String = prefs(context).getString(KEY_SIDO, "") ?: ""
+    fun getGu(context: Context): String = prefs(context).getString(KEY_GU, "") ?: ""
+    fun getDong(context: Context): String = prefs(context).getString(KEY_DONG, "") ?: ""
+    fun getNx(context: Context): Int = prefs(context).getInt(KEY_NX, -1)
+    fun getNy(context: Context): Int = prefs(context).getInt(KEY_NY, -1)
+
+    fun getLocationString(context: Context): String {
+        return "${getSido(context)} ${getGu(context)} ${getDong(context)}"
+    }
+}

--- a/app/src/main/java/com/pnu/myweather/feature/setting/view/SettingScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/setting/view/SettingScreenActivity.kt
@@ -25,7 +25,7 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.google.firebase.firestore.FirebaseFirestore      //firestore가 unresolved
 
-import com.pnu.myweather.util.LocationPreference
+
 
 class SettingScreenActivity : ComponentActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/java/com/pnu/myweather/feature/setting/view/SettingScreenActivity.kt
+++ b/app/src/main/java/com/pnu/myweather/feature/setting/view/SettingScreenActivity.kt
@@ -1,30 +1,39 @@
 package com.pnu.myweather.feature.setting.view
 
-import android.util.Log
 import android.os.Bundle
+import android.util.Log
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-
 import androidx.compose.material.icons.Icons
 import androidx.compose.material.icons.filled.ArrowBack
+import androidx.compose.material3.Button
+import androidx.compose.material3.DropdownMenuItem
 import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.ExposedDropdownMenuBox
+import androidx.compose.material3.ExposedDropdownMenuDefaults
 import androidx.compose.material3.Icon
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.Scaffold
 import androidx.compose.material3.Text
+import androidx.compose.material3.TextField
 import androidx.compose.material3.TopAppBar
-
-import androidx.compose.material3.*
-
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.*
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.MutableState
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateListOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.unit.dp
-import com.google.firebase.firestore.FirebaseFirestore      //firestore가 unresolved
-
+import com.google.firebase.firestore.FirebaseFirestore
 
 
 class SettingScreenActivity : ComponentActivity() {
@@ -123,7 +132,11 @@ fun SettingScreen(onGoBack: () -> Unit) {
                     selectedGu.value.isNotEmpty() &&
                     selectedDong.value.isNotEmpty()
                 ) {
-                    val docId = "${selectedSido.value}_${selectedGu.value}_${selectedDong.value}".replace(" ", "")
+                    val docId =
+                        "${selectedSido.value}_${selectedGu.value}_${selectedDong.value}".replace(
+                            " ",
+                            ""
+                        )
                     db.collection("locations").document(docId).get()
                         .addOnSuccessListener { document ->
                             if (document != null && document.exists()) {


### PR DESCRIPTION
### 개요
설정 화면에서 지역 저장 로직 구현

### 목적
MainScreen에서 저장된 지역의 좌표(nx, ny)와 지역명 확인을 위해 Shared Preferences에 지역 정보를 저장하는 로직을 구현한다.

### 변경사항
- /setting/view에 LocationPreference.kt 파일 추가
- SettingScreen에서 지역 저장 함수 LocationPreference.save 호출